### PR TITLE
[yan9vvoojin] 검색창 화면 구성하기

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,6 @@
     "eslint-config-prettier": "^8.8.0",
     "husky": "^8.0.3",
     "prettier": "^2.8.8"
-  }
+  },
+  "proxy": "https://api.clinicaltrialskorea.com"
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,11 @@
+import SearchBox from './components/SearchBox';
+
 const App = () => {
-  return <div className="App">Template</div>;
+  return (
+    <div className="App">
+      <SearchBox />
+    </div>
+  );
 };
 
 export default App;

--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -1,0 +1,38 @@
+import axios from 'axios';
+
+class ApiClient {
+  #host = '';
+
+  constructor(host) {
+    this.#host = host.replace(/(.*)(\/$)/, '$1');
+  }
+
+  async #request(method, path) {
+    const url = `${this.#host}/${path}`;
+
+    const config = {
+      url,
+      method,
+    };
+
+    try {
+      const response = await axios.request(config);
+      return response.data;
+    } catch (e) {
+      if (e.response) throw e.response;
+      throw e;
+    }
+  }
+
+  async #get(path) {
+    return await this.#request('GET', path);
+  }
+
+  async getSuggestions(keyword) {
+    return await this.#get('?name=' + keyword);
+  }
+}
+
+const apiClient = new ApiClient('/api/v1/search-conditions/');
+
+export default apiClient;

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import apiClient from '../api/apiClient';
+import Suggestions from './Suggestions';
+
+const SearchBox = () => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [suggestions, setSuggestions] = useState([]);
+  const [focusIndex, setFocusIndex] = useState(-1);
+  const [isComposing, setIsComposing] = useState(false);
+
+  const isEmptyInput = searchTerm.trim() === '';
+
+  const inputChangeHandler = (e) => {
+    setSearchTerm(e.target.value);
+    setFocusIndex(-1);
+  };
+
+  const inputKeyDownHandler = (e) => {
+    if (isComposing) return;
+    if (e.key === 'ArrowDown') {
+      setFocusIndex((prevFocusIndex) =>
+        prevFocusIndex < suggestions.length - 1 ? prevFocusIndex + 1 : 0
+      );
+    }
+    if (e.key === 'ArrowUp') {
+      setFocusIndex((prevFocusIndex) =>
+        prevFocusIndex > 0 ? prevFocusIndex - 1 : suggestions.length - 1
+      );
+    }
+    if (e.key === 'Enter' && focusIndex > -1) {
+      const { name } = suggestions[focusIndex];
+      setSearchTerm(name);
+      setFocusIndex(-1);
+    }
+  };
+
+  useEffect(() => {
+    if (isEmptyInput) return;
+
+    const updateSuggestions = async () => {
+      try {
+        const suggestions = await apiClient.getSuggestions(searchTerm);
+        setSuggestions(suggestions);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    updateSuggestions();
+  }, [isEmptyInput, searchTerm]);
+
+  return (
+    <>
+      <input
+        type="text"
+        placeholder="질환명을 입력해 주세요."
+        value={searchTerm}
+        onChange={inputChangeHandler}
+        onKeyDown={inputKeyDownHandler}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={() => setIsComposing(false)}
+      />
+      <Suggestions
+        suggestions={suggestions}
+        focusIndex={focusIndex}
+        isEmptyInput={isEmptyInput}
+        setFocusIndex={setFocusIndex}
+        setSearchTerm={setSearchTerm}
+      />
+    </>
+  );
+};
+
+export default SearchBox;

--- a/src/components/Suggestions.jsx
+++ b/src/components/Suggestions.jsx
@@ -1,0 +1,35 @@
+const Suggestions = ({
+  suggestions,
+  focusIndex,
+  isEmptyInput,
+  setFocusIndex,
+  setSearchTerm,
+}) => {
+  if (isEmptyInput) {
+    return null;
+  }
+
+  return (
+    <ul>
+      <span>추천 검색어</span>
+      <hr />
+      {suggestions.length > 0 ? (
+        suggestions.map((suggestion, index) => (
+          <li
+            style={{ color: focusIndex === index ? 'red' : 'black' }}
+            key={suggestion.id}
+            onMouseEnter={() => setFocusIndex(index)}
+            onMouseLeave={() => setFocusIndex(-1)}
+            onClick={() => setSearchTerm(suggestion.name)}
+          >
+            {suggestion.name}
+          </li>
+        ))
+      ) : (
+        <li>검색어 없음</li>
+      )}
+    </ul>
+  );
+};
+
+export default Suggestions;


### PR DESCRIPTION
- [x] 질환명 검색시 **API 호출** 통해서 검색어 추천 기능 구현
- [x] input onChange 시 추천 검색어 창에 “**검색어 없음**” 표출
- [x] 키보드만으로 추천 검색어들로 이동 가능하도록 구현하기
  - 키보드로 검색어 이동 후 엔터 시 인풋에 검색어 입력
---
![1](https://user-images.githubusercontent.com/106802169/235772883-7bcdef35-796b-405c-aaaa-104273c1a42f.gif)