### PR TITLE
[JunJongHun] 로컬 캐싱 구현하기

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,6 @@
     "eslint-config-prettier": "^8.8.0",
     "husky": "^8.0.3",
     "prettier": "^2.8.8"
-  }
+  },
+  "proxy": "https://api.clinicaltrialskorea.com"
 }

--- a/src/apis/apiClient.js
+++ b/src/apis/apiClient.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
+import { getCacheData, hasCacheKey, putCacheStorage } from '../utils/cache';
 
 const BASE_URL = 'https://api.clinicaltrialskorea.com/';
 const API_VERSION = 'api/v1/';
+
 class ApiClient {
   #options = {};
 
@@ -38,25 +40,10 @@ class ApiClient {
   async getCachedKeywords(keyword) {
     const URL = `${BASE_URL}${API_VERSION}search-conditions/?name=${keyword}`;
     const cacheStorage = await caches.open('keyword');
-    const responseCache = await cacheStorage.match(URL);
+    const cacheBoolean = await hasCacheKey(cacheStorage, URL);
 
-    try {
-      if (responseCache) return await responseCache.json();
-      else {
-        const { data, status, statusText, headers } = await this.getKeywords(
-          keyword
-        );
-        const fetchResponse = new Response(JSON.stringify(data), {
-          status,
-          statusText,
-          headers,
-        });
-        await cacheStorage.put(URL, fetchResponse);
-        return data;
-      }
-    } catch (err) {
-      alert(err);
-    }
+    if (cacheBoolean) return getCacheData(cacheStorage, keyword, URL);
+    else return putCacheStorage(cacheStorage, keyword, URL);
   }
 
   async getKeywords(keyword) {

--- a/src/apis/apiClient.js
+++ b/src/apis/apiClient.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+const BASE_URL = 'https://api.clinicaltrialskorea.com/';
+const API_VERSION = 'api/v1/';
 class ApiClient {
   #options = {};
 
@@ -33,11 +35,35 @@ class ApiClient {
     return await this.#request('GET', path);
   }
 
-  async getKeyword(keyword) {
-    return await this.#get(`?name=${keyword}`);
+  async getCachedKeywords(keyword) {
+    const URL = `${BASE_URL}${API_VERSION}search-conditions/?name=${keyword}`;
+    const cacheStorage = await caches.open('keyword');
+    const responseCache = await cacheStorage.match(URL);
+
+    try {
+      if (responseCache) return await responseCache.json();
+      else {
+        const { data, status, statusText, headers } = await this.getKeywords(
+          keyword
+        );
+        const fetchResponse = new Response(JSON.stringify(data), {
+          status,
+          statusText,
+          headers,
+        });
+        await cacheStorage.put(URL, fetchResponse);
+        return data;
+      }
+    } catch (err) {
+      alert(err);
+    }
+  }
+
+  async getKeywords(keyword) {
+    return await this.#get(`search-conditions/?name=${keyword}`);
   }
 }
 
 export const apiClient = new ApiClient({
-  HOST: 'https://api.clinicaltrialskorea.com/api/v1/search-conditions/',
+  HOST: API_VERSION,
 });

--- a/src/apis/apiClient.js
+++ b/src/apis/apiClient.js
@@ -47,6 +47,7 @@ class ApiClient {
   }
 
   async getKeywords(keyword) {
+    console.info('calling api');
     return await this.#get(`search-conditions/?name=${keyword}`);
   }
 }

--- a/src/hooks/useKeywordSuggestion.js
+++ b/src/hooks/useKeywordSuggestion.js
@@ -7,8 +7,8 @@ const useKeywordSuggestion = (keyword) => {
   const fetchSuggestions = useCallback(async () => {
     try {
       if (keyword) {
-        const response = await apiClient.getKeyword(keyword);
-        setSuggestions(response.data);
+        const response = await apiClient.getCachedKeywords(keyword);
+        setSuggestions(response);
       } else {
         setSuggestions([]);
       }

--- a/src/hooks/useKeywordSuggestion.js
+++ b/src/hooks/useKeywordSuggestion.js
@@ -18,7 +18,10 @@ const useKeywordSuggestion = (keyword) => {
   }, [keyword]);
 
   useEffect(() => {
-    fetchSuggestions();
+    const timer = setTimeout(() => {
+      fetchSuggestions();
+    }, 400);
+    return () => clearTimeout(timer);
   }, [fetchSuggestions]);
 
   return [suggestions];

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,0 +1,45 @@
+import { apiClient } from '../apis/apiClient';
+
+const KEY = 'expire';
+const EXPIRETIME = 60 * 1000; //1분
+
+export function createFetchResponse(axiosResponse) {
+  const { data, status, statusText, headers } = axiosResponse;
+  const newHeaders = setExpireTime(headers);
+  const fetchResponse = new Response(JSON.stringify(data), {
+    status,
+    statusText,
+    headers: newHeaders,
+  });
+  return fetchResponse;
+}
+
+export function setExpireTime(headers) {
+  const newHeaders = new Headers(headers);
+  newHeaders.set(KEY, new Date(Date.now() + EXPIRETIME).toUTCString());
+  return newHeaders;
+}
+
+export async function isExpiredTime(responseCache) {
+  const expireTime = await responseCache.headers.get(KEY);
+  return Date.now() - new Date(expireTime).getTime() > 0;
+}
+
+export async function hasCacheKey(cacheStorage, url) {
+  return Boolean(await cacheStorage.match(url));
+}
+
+export async function putCacheStorage(cacheStorage, keyword, url) {
+  const axiosResponse = await apiClient.getKeywords(keyword);
+  const fetchResponse = createFetchResponse(axiosResponse);
+  await cacheStorage.put(url, fetchResponse);
+  return axiosResponse.data;
+}
+
+export async function getCacheData(cacheStorage, keyword, url) {
+  const responseCache = await cacheStorage.match(url);
+  const expiredTimeBoolean = isExpiredTime(responseCache);
+  return expiredTimeBoolean
+    ? responseCache.json()
+    : putCacheStorage(cacheStorage, keyword, URL);
+}

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,7 +1,7 @@
 import { apiClient } from '../apis/apiClient';
 
 const KEY = 'expire';
-const EXPIRETIME = 60 * 1000; //1분
+const EXPIRETIME = 10 * 1000; //1분
 
 export function createFetchResponse(axiosResponse) {
   const { data, status, statusText, headers } = axiosResponse;
@@ -38,8 +38,9 @@ export async function putCacheStorage(cacheStorage, keyword, url) {
 
 export async function getCacheData(cacheStorage, keyword, url) {
   const responseCache = await cacheStorage.match(url);
-  const expiredTimeBoolean = isExpiredTime(responseCache);
-  return expiredTimeBoolean
-    ? responseCache.json()
-    : putCacheStorage(cacheStorage, keyword, URL);
+  const expiredTimeBoolean = await isExpiredTime(responseCache);
+  if (expiredTimeBoolean) {
+    await cacheStorage.delete(url);
+    return await putCacheStorage(cacheStorage, keyword, url);
+  } else return responseCache.json();
 }


### PR DESCRIPTION
- [x] 1. 캐싱 구현 - API로 호출한 데이터를 **캐시 스토리지**에 저장
- [x] 2. expire time 구현 - 데이터 저장할 때, Expire Time 포함해서 저장
- [x] 3. 입력마다 API 호출하지 않도록 API 호출 횟수를 줄이는 기능 구현 
- [x] 4. API를 호출할 때 마다 console.info("calling api") 출력 

---
### 캐싱 및 expire time 구현
- cache Storage 저장 할 때, headers에 expire time 추가 저장

