### PR TITLE
[hyukzz] 로컬 캐싱 구현하기 & API 호출 횟수 최적화 구현

### DIFF
--- a/src/apis/apiClient.js
+++ b/src/apis/apiClient.js
@@ -5,6 +5,11 @@ class ApiClient {
 
   constructor(options) {
     this.#options.HOST = options.HOST.replace(/(.*)(\/$)/, '$1');
+
+    axios.interceptors.request.use((requestConfig) => {
+      console.info('calling api');
+      return requestConfig;
+    });
   }
 
   async #request(method, path, data) {

--- a/src/components/SearchBarInput.js
+++ b/src/components/SearchBarInput.js
@@ -3,7 +3,7 @@ import React from 'react';
 const SearchBarInput = ({ keyword, handleInputChange, handleKeyDown }) => {
   return (
     <input
-      type="text"
+      type="search"
       value={keyword}
       onChange={handleInputChange}
       onKeyDown={handleKeyDown}

--- a/src/components/SuggestionItem.js
+++ b/src/components/SuggestionItem.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const SuggestionItem = ({
+  index,
+  focusedIndex,
+  setFocusedIndex,
+  suggestionName,
+}) => {
+  return (
+    <li
+      key={index}
+      style={index === focusedIndex ? { backgroundColor: '#eee' } : {}}
+      onClick={() => setFocusedIndex(index)}
+    >
+      <span>{suggestionName}</span>
+    </li>
+  );
+};
+
+export default SuggestionItem;

--- a/src/components/SuggestionList.js
+++ b/src/components/SuggestionList.js
@@ -1,20 +1,45 @@
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
+import SuggestionItem from './SuggestionItem';
+import { MAX_SUGGESTIONS } from '../constants/constants';
 
 const SuggestionList = ({ suggestions, focusedIndex, setFocusedIndex }) => {
   const suggestionListRef = useRef(null);
 
+  const startIndex = Math.max(0, focusedIndex - MAX_SUGGESTIONS + 1);
+
+  const renderedSuggestions = suggestions.slice(
+    startIndex,
+    startIndex + MAX_SUGGESTIONS
+  );
+
+  useEffect(() => {
+    setFocusedIndex(-1);
+  }, [suggestions, setFocusedIndex]);
+
   return (
-    <ul ref={suggestionListRef}>
-      {suggestions.map((suggestion, index) => (
-        <li
-          key={index}
-          style={index === focusedIndex ? { backgroundColor: '#ccc' } : {}}
-          onClick={() => setFocusedIndex(index)}
-        >
-          {suggestion.name}
-        </li>
-      ))}
-    </ul>
+    <>
+      <ul ref={suggestionListRef}>
+        {suggestions.length <= MAX_SUGGESTIONS
+          ? suggestions.map((suggestion, index) => (
+              <SuggestionItem
+                key={index}
+                index={index}
+                focusedIndex={focusedIndex}
+                setFocusedIndex={setFocusedIndex}
+                suggestionName={suggestion.name}
+              />
+            ))
+          : renderedSuggestions.map((suggestion, index) => (
+              <SuggestionItem
+                key={index}
+                index={startIndex + index}
+                focusedIndex={focusedIndex}
+                setFocusedIndex={setFocusedIndex}
+                suggestionName={suggestion.name}
+              />
+            ))}
+      </ul>
+    </>
   );
 };
 

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,0 +1,3 @@
+export const MAX_SUGGESTIONS = 7;
+export const CACHE_PREFIX = 'cache_';
+export const EXPIRATION_TIME_IN_MS = 5000;

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+const useDebounce = (value, delay) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,5 +1,4 @@
-const CACHE_PREFIX = 'cache_';
-const EXPIRATION_TIME_IN_MS = 5000;
+import { CACHE_PREFIX, EXPIRATION_TIME_IN_MS } from '../constants/constants';
 
 const getCacheKey = (key) => {
   return CACHE_PREFIX + key;

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,0 +1,59 @@
+const CACHE_PREFIX = 'cache_';
+const EXPIRATION_TIME_IN_MS = 5000;
+
+const getCacheKey = (key) => {
+  return CACHE_PREFIX + key;
+};
+
+const cacheData = (key, data) => {
+  const cacheEntry = {
+    data,
+    expiresAt: Date.now() + EXPIRATION_TIME_IN_MS,
+  };
+  localStorage.setItem(getCacheKey(key), JSON.stringify(cacheEntry));
+};
+
+const getFromCache = (key) => {
+  const cacheEntry = localStorage.getItem(getCacheKey(key));
+  if (cacheEntry) {
+    const { data, expiresAt } = JSON.parse(cacheEntry);
+    if (Date.now() < expiresAt) {
+      return data;
+    } else {
+      localStorage.removeItem(getCacheKey(key));
+    }
+  }
+
+  return null;
+};
+
+const startCacheCleanUpInterval = () => {
+  const cleanUpIntervalId = setInterval(() => {
+    const now = Date.now();
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key.startsWith(CACHE_PREFIX)) {
+        const cacheEntry = localStorage.getItem(key);
+        if (cacheEntry) {
+          const { expiresAt } = JSON.parse(cacheEntry);
+          if (now >= expiresAt) {
+            localStorage.removeItem(key);
+          }
+        }
+      }
+    }
+  }, EXPIRATION_TIME_IN_MS);
+
+  return cleanUpIntervalId;
+};
+
+const stopCacheCleanUpInterval = (intervalId) => {
+  clearInterval(intervalId);
+};
+
+export {
+  cacheData,
+  getFromCache,
+  startCacheCleanUpInterval,
+  stopCacheCleanUpInterval,
+};


### PR DESCRIPTION
## 구현사항
1. API 호출시 로컬 캐싱 구현하기
  - 캐싱 구현
  - expire time을 구현
  
2. 호출 횟수 줄이기
  - 입력마다 API 호출하지 않도록 API 호출 횟수를 줄이는 기능 (debounce)
  - API를 호출할 때 마다 `console.info("calling api")` 출력

## 문제점 발견
1. 검색어량이 많을 때, UI/UX가 보기 안 좋음
해결 -> 최대 7개의 검색어를 보여줌

2. 추천검색어 수를 고정하니 7개미만의 값은 안 나옴
해결 -> 추천검색어 7개 기준으로 조건 추가 
추가사항 -> 8번 째 검색어부터는 최대 7개의 검색어 비율을 유지하며 포커싱되고, 마지막 검색어에서 keydown시 1번 째(0번 째 index) 검색어로 이동

3. 검색어를 사용하고 다른 검색어를 다시 검색할 때 포커싱 index 값이 고정되어 포커싱위치가 초기화되지 않는 문제 
해결 ->  포커싱된 Index를 새로운 검색어로 바꿀 때 포커싱 위치를 초기화 시킴

## 구현화면
### 1. UI/UX를 고려한 추천검색어량 조절 및 컨트롤
![검색창 7개](https://user-images.githubusercontent.com/81045794/236171831-363ef484-3e28-46c3-808d-0d1d2bd857b7.gif)

### 2. localstorage에 캐싱돼 있을 때, 중복 api 호출 시 캐싱된 데이터를 사용
![검색창 캐싱](https://user-images.githubusercontent.com/81045794/236111373-46a19bfd-4b63-4faf-a0a2-9d6208129321.gif)

### 3. 호출한 api에 대한 데이터가 있으면 api 재호출을 안하고, 적절한 debounce 시간을 부여해서 불필요한 단어에 대한 api 호출을 줄임
![검색창 디바운스](https://user-images.githubusercontent.com/81045794/236111991-b4141ee0-6a61-44ef-9b56-11bf518a2fa0.gif)

#2 #3 