### PR TITLE
[blueline1984] 로컬 캐싱 구현하기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.4.0",
+        "http-proxy-middleware": "^2.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.4.0",
+    "http-proxy-middleware": "^2.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.0",

--- a/src/apis/apiClient.js
+++ b/src/apis/apiClient.js
@@ -39,5 +39,5 @@ class ApiClient {
 }
 
 export const apiClient = new ApiClient({
-  HOST: 'https://api.clinicaltrialskorea.com/api/v1/search-conditions/',
+  HOST: '/api/v1/search-conditions/',
 });

--- a/src/components/SuggestionList.js
+++ b/src/components/SuggestionList.js
@@ -1,8 +1,9 @@
 import React, { useRef } from 'react';
+import useKeyboard from '../hooks/useKeyboard';
 
-const SuggestionList = ({ suggestions, focusedIndex, setFocusedIndex }) => {
+const SuggestionList = ({ suggestions }) => {
   const suggestionListRef = useRef(null);
-  console.log(suggestionListRef);
+  const { focusedIndex, setFocusedIndex } = useKeyboard();
   return (
     <ul ref={suggestionListRef}>
       {suggestions.map((suggestion, index) => (

--- a/src/components/SuggestionList.js
+++ b/src/components/SuggestionList.js
@@ -2,12 +2,12 @@ import React, { useRef } from 'react';
 
 const SuggestionList = ({ suggestions, focusedIndex, setFocusedIndex }) => {
   const suggestionListRef = useRef(null);
-
+  console.log(suggestionListRef);
   return (
     <ul ref={suggestionListRef}>
       {suggestions.map((suggestion, index) => (
         <li
-          key={index}
+          key={suggestion?.id}
           style={index === focusedIndex ? { backgroundColor: '#ccc' } : {}}
           onClick={() => setFocusedIndex(index)}
         >

--- a/src/hooks/useKeyboard.js
+++ b/src/hooks/useKeyboard.js
@@ -1,10 +1,9 @@
-const useKeyboard = (
-  suggestions,
-  focusedIndex,
-  setFocusedIndex,
-  setKeyword
-) => {
-  const handleKeyDown = (e) => {
+import { useState } from 'react';
+
+const useKeyboard = (setKeyword) => {
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+
+  const handleKeyDown = (e, suggestions) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
 
@@ -28,7 +27,7 @@ const useKeyboard = (
     }
   };
 
-  return handleKeyDown;
+  return { focusedIndex, setFocusedIndex, handleKeyDown };
 };
 
 export default useKeyboard;

--- a/src/hooks/useKeywordSuggestion.js
+++ b/src/hooks/useKeywordSuggestion.js
@@ -8,8 +8,6 @@ const API_REQUEST_TIMER = 1000;
 const useKeywordSuggestion = (keyword) => {
   const [suggestions, setSuggestions] = useState([]);
 
-  console.log(suggestionsCache);
-
   useEffect(() => {
     const fetchSuggestions = async () => {
       try {
@@ -18,7 +16,6 @@ const useKeywordSuggestion = (keyword) => {
           const data = response.data;
           console.info('calling api');
           setSuggestions(data);
-          //캐쉬에 저장되어 있지 않은 경우, 캐쉬에 저장 & expire time 설정
           suggestionsCache[keyword] = { data, timeStamp: Date.now() };
         } else {
           setSuggestions([]);
@@ -26,27 +23,6 @@ const useKeywordSuggestion = (keyword) => {
       } catch (error) {
         console.error(error);
       }
-
-      //캐쉬를 검색 후 캐쉬에 저장되어 있으면 캐쉬에 저장된 데이터를 사용
-      // if (cache[keyword]) {
-      //   setSuggestions(cache[keyword].data);
-      // } else {
-      //   try {
-      //     if (keyword) {
-      //       const response = await apiClient.getKeyword(keyword);
-      //       const data = response.data;
-      //       setSuggestions(data);
-      //       //캐쉬에 저장 & expire time 설정
-      //       cache[keyword] = {};
-      //       cache[keyword].data = data;
-      //       cache[keyword].timeStamp = Date.now();
-      //     } else {
-      //       setSuggestions([]);
-      //     }
-      //   } catch (error) {
-      //     console.error(error);
-      //   }
-      // }
     };
 
     const getSuggestions = async () => {
@@ -57,19 +33,12 @@ const useKeywordSuggestion = (keyword) => {
       }
 
       if (!data) {
-        data = await fetchSuggestions(); // Fetch new data
+        data = await fetchSuggestions();
       }
     };
 
-    /** 실행부분 */
     const timeout = setTimeout(() => {
       getSuggestions();
-
-      //   if (data === null || undefined) {
-      //     console.log('최초 한번 실행, 시간 지나고 실행');
-      //     data = fetchSuggestions();
-      //     setSuggestions(data);
-      //   }
     }, API_REQUEST_TIMER);
 
     return () => clearTimeout(timeout);

--- a/src/hooks/useKeywordSuggestion.js
+++ b/src/hooks/useKeywordSuggestion.js
@@ -1,12 +1,14 @@
 import { useState, useEffect } from 'react';
 import { apiClient } from '../apis/apiClient';
-import getCacheData from '../utils/getCacheData';
 import { suggestionsCache } from '../store/cache';
+import getCacheData from '../utils/getCacheData';
 
 const API_REQUEST_TIMER = 1000;
 
 const useKeywordSuggestion = (keyword) => {
   const [suggestions, setSuggestions] = useState([]);
+
+  console.log(suggestionsCache);
 
   useEffect(() => {
     const fetchSuggestions = async () => {
@@ -50,6 +52,10 @@ const useKeywordSuggestion = (keyword) => {
     const getSuggestions = async () => {
       let data = getCacheData(suggestionsCache, keyword);
 
+      if (data) {
+        setSuggestions(data);
+      }
+
       if (!data) {
         data = await fetchSuggestions(); // Fetch new data
       }
@@ -66,9 +72,7 @@ const useKeywordSuggestion = (keyword) => {
       //   }
     }, API_REQUEST_TIMER);
 
-    return () => {
-      clearTimeout(timeout);
-    };
+    return () => clearTimeout(timeout);
   }, [keyword]);
 
   return [suggestions];

--- a/src/hooks/useKeywordSuggestion.js
+++ b/src/hooks/useKeywordSuggestion.js
@@ -1,25 +1,75 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { apiClient } from '../apis/apiClient';
+import getCacheData from '../utils/getCacheData';
+import { suggestionsCache } from '../store/cache';
+
+const API_REQUEST_TIMER = 1000;
 
 const useKeywordSuggestion = (keyword) => {
   const [suggestions, setSuggestions] = useState([]);
 
-  const fetchSuggestions = useCallback(async () => {
-    try {
-      if (keyword) {
-        const response = await apiClient.getKeyword(keyword);
-        setSuggestions(response.data);
-      } else {
-        setSuggestions([]);
-      }
-    } catch (error) {
-      console.error(error);
-    }
-  }, [keyword]);
-
   useEffect(() => {
-    fetchSuggestions();
-  }, [fetchSuggestions]);
+    const fetchSuggestions = async () => {
+      try {
+        if (keyword) {
+          const response = await apiClient.getKeyword(keyword);
+          const data = response.data;
+          console.info('calling api');
+          setSuggestions(data);
+          //캐쉬에 저장되어 있지 않은 경우, 캐쉬에 저장 & expire time 설정
+          suggestionsCache[keyword] = { data, timeStamp: Date.now() };
+        } else {
+          setSuggestions([]);
+        }
+      } catch (error) {
+        console.error(error);
+      }
+
+      //캐쉬를 검색 후 캐쉬에 저장되어 있으면 캐쉬에 저장된 데이터를 사용
+      // if (cache[keyword]) {
+      //   setSuggestions(cache[keyword].data);
+      // } else {
+      //   try {
+      //     if (keyword) {
+      //       const response = await apiClient.getKeyword(keyword);
+      //       const data = response.data;
+      //       setSuggestions(data);
+      //       //캐쉬에 저장 & expire time 설정
+      //       cache[keyword] = {};
+      //       cache[keyword].data = data;
+      //       cache[keyword].timeStamp = Date.now();
+      //     } else {
+      //       setSuggestions([]);
+      //     }
+      //   } catch (error) {
+      //     console.error(error);
+      //   }
+      // }
+    };
+
+    const getSuggestions = async () => {
+      let data = getCacheData(suggestionsCache, keyword);
+
+      if (!data) {
+        data = await fetchSuggestions(); // Fetch new data
+      }
+    };
+
+    /** 실행부분 */
+    const timeout = setTimeout(() => {
+      getSuggestions();
+
+      //   if (data === null || undefined) {
+      //     console.log('최초 한번 실행, 시간 지나고 실행');
+      //     data = fetchSuggestions();
+      //     setSuggestions(data);
+      //   }
+    }, API_REQUEST_TIMER);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [keyword]);
 
   return [suggestions];
 };

--- a/src/pages/SearchBar.js
+++ b/src/pages/SearchBar.js
@@ -10,6 +10,7 @@ const SearchBar = () => {
   const [keyword, handleInputChange, setKeyword] = useInputChange();
   const [suggestions] = useKeywordSuggestion(keyword);
 
+  console.log(keyword);
   const handleKeyDown = useKeyboard(
     suggestions,
     focusedIndex,

--- a/src/pages/SearchBar.js
+++ b/src/pages/SearchBar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import useKeywordSuggestion from '../hooks/useKeywordSuggestion';
 import useInputChange from '../hooks/useInputChange';
 import useKeyboard from '../hooks/useKeyboard';
@@ -6,31 +6,19 @@ import SearchBarInput from '../components/SearchBarInput';
 import SuggestionList from '../components/SuggestionList';
 
 const SearchBar = () => {
-  const [focusedIndex, setFocusedIndex] = useState(-1);
   const [keyword, handleInputChange, setKeyword] = useInputChange();
   const [suggestions] = useKeywordSuggestion(keyword);
-
-  const handleKeyDown = useKeyboard(
-    suggestions,
-    focusedIndex,
-    setFocusedIndex,
-    setKeyword
-  );
-
+  const { handleKeyDown } = useKeyboard(suggestions, setKeyword);
   return (
     <>
       <SearchBarInput
         keyword={keyword}
         handleInputChange={handleInputChange}
-        handleKeyDown={handleKeyDown}
+        handleKeyDown={(e) => handleKeyDown(e, suggestions)}
       />
 
       {keyword && suggestions?.length > 0 ? (
-        <SuggestionList
-          suggestions={suggestions}
-          focusedIndex={focusedIndex}
-          setFocusedIndex={setFocusedIndex}
-        />
+        <SuggestionList suggestions={suggestions} />
       ) : (
         <div>검색어 없음</div>
       )}

--- a/src/pages/SearchBar.js
+++ b/src/pages/SearchBar.js
@@ -10,7 +10,6 @@ const SearchBar = () => {
   const [keyword, handleInputChange, setKeyword] = useInputChange();
   const [suggestions] = useKeywordSuggestion(keyword);
 
-  console.log(keyword);
   const handleKeyDown = useKeyboard(
     suggestions,
     focusedIndex,

--- a/src/pages/SearchBar.js
+++ b/src/pages/SearchBar.js
@@ -25,7 +25,7 @@ const SearchBar = () => {
         handleKeyDown={handleKeyDown}
       />
 
-      {keyword && suggestions.length > 0 ? (
+      {keyword && suggestions?.length > 0 ? (
         <SuggestionList
           suggestions={suggestions}
           focusedIndex={focusedIndex}

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,11 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function (app) {
+  app.use(
+    '/api',
+    createProxyMiddleware({
+      target: 'https://api.clinicaltrialskorea.com',
+      changeOrigin: true,
+    })
+  );
+};

--- a/src/store/cache.js
+++ b/src/store/cache.js
@@ -1,0 +1,3 @@
+const suggestionsCache = {};
+
+export { suggestionsCache };

--- a/src/store/cache.js
+++ b/src/store/cache.js
@@ -1,3 +1,5 @@
+const CACHE_EXPIRATION_TIME = 500000;
+
 const suggestionsCache = {};
 
-export { suggestionsCache };
+export { suggestionsCache, CACHE_EXPIRATION_TIME };

--- a/src/utils/getCacheData.js
+++ b/src/utils/getCacheData.js
@@ -1,0 +1,32 @@
+const getCacheData = (cache, keyword) => {
+  const CACHE_EXPIRATION_TIME = 5000;
+
+  // 역할: 저장된 캐쉬를 반환한다
+  /** 단계
+   * 1. 해당 키워드를 사용해서 데이터가 캐싱되어있는지 확인한다.
+   * 2. 있는 경우,
+   *  2-1 expire time이 유효한지 확인한다. -> 어떻게 확일할 수 있을까?
+   *  2-2 유효하면 해당 데이터 반환한다.
+   *  2-3 유효하지 않으면 해당 데이터를 초기화 한다.
+   * 3. 없는 경우 null을 반환한다.
+   */
+  if (cache[keyword]) {
+    // 저장되어 있다.
+    const { timeStamp, data } = cache[keyword];
+    const expirationTime = timeStamp + CACHE_EXPIRATION_TIME;
+
+    if (expirationTime < Date.now()) {
+      console.log('시간지남');
+      //시간이 지났다 -> 해당 데이터 파기(초기화)
+      cache[keyword] = {};
+    } else {
+      //시간이 유효하다 -> 해당 데이터 사용
+      return data;
+    }
+  } else {
+    // 저장안되어 있다.
+    return null;
+  }
+};
+
+export default getCacheData;

--- a/src/utils/getCacheData.js
+++ b/src/utils/getCacheData.js
@@ -1,29 +1,16 @@
 import { CACHE_EXPIRATION_TIME } from '../store/cache';
+
 const getCacheData = (cache, keyword) => {
-  // 역할: 저장된 캐쉬를 반환한다
-  /** 단계
-   * 1. 해당 키워드를 사용해서 데이터가 캐싱되어있는지 확인한다.
-   * 2. 있는 경우,
-   *  2-1 expire time이 유효한지 확인한다. -> 어떻게 확일할 수 있을까?
-   *  2-2 유효하면 해당 데이터 반환한다.
-   *  2-3 유효하지 않으면 해당 데이터를 초기화 한다.
-   * 3. 없는 경우 null을 반환한다.
-   */
   if (cache[keyword]) {
-    // 저장되어 있다.
     const { timeStamp, data } = cache[keyword];
     const expirationTime = timeStamp + CACHE_EXPIRATION_TIME;
 
     if (expirationTime < Date.now()) {
-      console.log('시간지남');
-      //시간이 지났다 -> 해당 데이터 파기(초기화)
       cache[keyword] = {};
     } else {
-      //시간이 유효하다 -> 해당 데이터 사용
       return data;
     }
   } else {
-    // 저장안되어 있다.
     return null;
   }
 };

--- a/src/utils/getCacheData.js
+++ b/src/utils/getCacheData.js
@@ -1,6 +1,5 @@
+import { CACHE_EXPIRATION_TIME } from '../store/cache';
 const getCacheData = (cache, keyword) => {
-  const CACHE_EXPIRATION_TIME = 5000;
-
   // 역할: 저장된 캐쉬를 반환한다
   /** 단계
    * 1. 해당 키워드를 사용해서 데이터가 캐싱되어있는지 확인한다.


### PR DESCRIPTION
- [x] 로컬 캐싱 구현 - API로 호출한 데이터를 localStorage에 캐싱
- [x] expire time 구현 - localStorage에 Expire Time 포함해서 저장, 입력값 받아올 때 저장된 Expire Time과 비교
- [x] 입력마다 API 호출하지 않도록 API 호출 횟수를 줄이기
- [x] API를 호출할 때 마다 console.info("calling api") 출력

## 구현 및 변경사항
### useCallback 수정
- `useCallback`의 사용은 메모리에 해당 함수가 저장되므로 최후의 수단으로 생각하였습니다.
- `fetchSuggestions` 함수를 다른 곳에서 사용하지 않기 때문에 effect 내부로 선언하여 호출하는 방식으로 리팩토링 했습니다.

### 로컬 캐싱 및 API 호출 최적화 기능 구현
- 타이머 상수 선언하여 api 호출 시간 설정할 수 있도록 하였습니다
- 어디에서 캐쉬의 만료 시간을 초기화하고 해당 키워드로 저장해야하는가에 대해 어려움이 있었음
- 캐싱할 때 로컬 스토리지 저장하지 않고 프론트단 store에 저장하는 방식으로 구현하였습니다.
- 캐시를 저장, 삭제하는 기능을 함수형태로 만들었습니다. `getCacheData`

### useKeydown 리팩토링
- 기존의 useKeydown 훅은 내부에 React 의 내장된 훅을 사용하지 않았기때문에 커스텀훅으로 분리할 수 없습니다.
- 기존의 로직을 변경하면서 useKeyboard 초기에 두번 렌더링 되어 index 값이 -1 에서 0이 아닌 1로 증가하는 문제를 발견했습니다.
- `useState`를 사용하여 `focusedIndex` 상태를 useKeydown 로직으로 이동시켰습니다.

## 미해결
- 검색어 입력 후 다음 검색어 입력시에 이전에 저장되어 있던 값이 화면에 한번 보이는 현상이 발생했습니다. 이는 setTimeout이 클리어 되기 전의 중간에 발생하는 것으로 원인을 파악하였지만 해결하지 못하였습니다.
- useKeydown 커스텀 훅이 초기화 되는 현상이 발생하여 index가 -1로 초기화 됩니다. 추후 해결 필요합니다.